### PR TITLE
configuration: allow some trimming options to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Bundle 'derekprior/vim-trimmer'
 Run the `:BundleInstall` command and you're off.
 
 ## Configuration
+
 To opt certain filetypes out of the autocommand, add them to the blacklist
 array like so: `let g:trimmer_blacklist = ['markdown', 'make']`.
+
+To trim repeated empty lines within a given whitelisted file set a global
+variable like so: `let g:trimmer_repeated_empty_lines = 1`.
+
+To trim empty lines at the end of a given whitelisted file set a variable like
+so: `let g:trimmer_trailing_empty_lines = 1`.
 
 [v]:https://github.com/gmarik/vundle

--- a/doc/trimmer.txt
+++ b/doc/trimmer.txt
@@ -25,8 +25,8 @@ BufPreWrite to do its work.
 On write, the following whitespace will be eliminated:
 
   1. Trailing whitespace on each line
-  2. Trailing newlines at the end of the file
-  3. Repeated empty lines in a file
+  2. Trailing newlines at the end of the file (optionally)
+  3. Repeated empty lines in a file (optionally)
 
 ====================================================================
 Section 2: Configuration                       *TrimmerConfiguration*
@@ -36,6 +36,16 @@ where trailing whitespace is meaningul. You can opt filetypes out of
 whitespace trimming with:
 
   let g:trimmer_blacklist = ['markdown']
+
+To trim repeated empty lines within a given whitelisted file set a
+global variable like so:
+
+  let g:trimmer_repeated_empty_lines = 1
+
+To trim empty lines at the end of a given whitelisted file set a
+global variable like so:
+
+  let g:trimmer_trailing_empty_lines = 1
 
 ====================================================================
 vim:tw=78:ft=help:norl:

--- a/plugin/vim-trimmer.vim
+++ b/plugin/vim-trimmer.vim
@@ -11,8 +11,12 @@ function! s:TrimTrailingWhitespace(blacklist)
   if index(a:blacklist, &ft) < 0
     let l:pos = getpos(".")
     %s/\s\+$//e
-    %s/\n\{3,}/\r\r/e
-    %s#\($\n\s*\)\+\%$##e
+    if exists(g:trimmer_repeated_empty_lines)
+      %s/\n\{3,}/\r\r/e
+    endif
+    if exists(g:trimmer_trailing_empty_lines)
+      %s#\($\n\s*\)\+\%$##e
+    endif
     call setpos(".", l:pos)
   endif
 endfunction


### PR DESCRIPTION
There is a balance to be struck when trimming empty lines. Trimming the
empty lines at the bottom and the repeated empty lines within a file
could be seen as too much noise for a diff. Too often if either of the
previous mentioned cases are violated it is more than just one or two
instances within the file and really starts to detract from the
important parts of the diff. Instead, these features should be
considered options, easily enabled or disabled, either at runtime or
startup.
