### PR TITLE
Don't collapse two repeated empty lines

### DIFF
--- a/plugin/vim-trimmer.vim
+++ b/plugin/vim-trimmer.vim
@@ -11,7 +11,7 @@ function! s:TrimTrailingWhitespace(blacklist)
   if index(a:blacklist, &ft) < 0
     let l:pos = getpos(".")
     %s/\s\+$//e
-    %s/\n\{3,}/\r\r/e
+    %s/\n\{4,}/\r\r\r/e
     %s#\($\n\s*\)\+\%$##e
     call setpos(".", l:pos)
   endif


### PR DESCRIPTION
Two empty lines are often used to provide intentional visual separation between code blocks. For example, the Python style guide PEP 8 [states](https://www.python.org/dev/peps/pep-0008/#blank-lines):

> Surround top-level function and class definitions with two blank lines.

This commit makes vim-trimmer only collapse repeated empty lines when there are more than two empty lines, and collapses them to two empty lines rather than a single empty line. This allows vim-trimmer to be used when editing Python.
