### PR TITLE
Remove the whitespace search from search history

### DIFF
--- a/plugin/vim-trimmer.vim
+++ b/plugin/vim-trimmer.vim
@@ -11,6 +11,7 @@ function! s:TrimTrailingWhitespace(blacklist)
   if index(a:blacklist, &filetype) < 0
     let l:pos = getpos('.')
     %s/\s\+$//e
+    call histdel('search', -1)
     call setpos('.', l:pos)
   endif
 endfunction


### PR DESCRIPTION
When continuing to edit a file, prefer to keep the last real search at the top of the search history.